### PR TITLE
Expand tokenizer support: Config method, Bos/Eos token support, and SentencePiece post-processing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,15 +3,22 @@
 ## Next
 
 - Package `tokenizers`: **API change!**
-  - Updated `Tokenizer` interface to include `EncodeWithAnnotations`, `VocabSize()` and `Normalize()` methods, and cleaned up the API.
+  - Updated `api.Tokenizer` interface: added `EncodeWithAnnotations`, `VocabSize()`, `Normalize()` and `Config` methods,
+    and cleaned up the API.
+- Package `tokenizers/hftokenizer`:
+  - Added support to `AddBosToken` and `AddEosToken`.
+- Package `tokenizers/sentencepiece`:
+  - Added post-processing.
+  - Spans only generated for `EncodeWithAnnotations`.
+  - Added support to `AddBosToken` and `AddEosToken`.
+- Package `tokenizers/bucket`
+  - Added `bucket` package for streaming tokenization of sentences into buckets (or batches) of discrete sizes, 
+    to minimize padding.
 - Package `datasets`:
   - Added `datasets` package for downloading and iterating over parquet files of datasets from the HuggingFace Hub.
   - Added `cmd/generate_dataset_structs` for generating Go structs for dataset records.
   - Added `ParquetFixListSchema` for fixing list schema parsed from Go struct (a bug? in parquet-go where it hard-codes
     the group/element node names in lists).
-- Package `tokenizers/bucket`
-  - Added `bucket` package for streaming tokenization of sentences into buckets (or batches) of discrete sizes, 
-    to minimize padding.
 - Package `transformer`
   - Renamed main method to `AllLayers`: it returns both the final hidden state and all layer outputs; 
     it added RoPE positional embeddings support; added support for scaling factor.

--- a/tokenizers/api/api.go
+++ b/tokenizers/api/api.go
@@ -40,6 +40,10 @@ type Tokenizer interface {
 
 	// VocabSize returns the total number of tokens in the vocabulary.
 	VocabSize() int
+
+	// Config returns the HuggingFace tokenizer configuration.
+	// It is optional, and in case the tokenizer has been instantiated in some other fashion it may return nil.
+	Config() *Config
 }
 
 // AnnotatedEncoding contains various optional annotations.

--- a/tokenizers/api/api.go
+++ b/tokenizers/api/api.go
@@ -69,6 +69,8 @@ type TokenSpan struct {
 type EncodeOptions struct {
 
 	// AddSpecialTokens option takes a boolean value, and enables post-processing (e.g., [CLS]/[SEP] for BERT).
+	// This is enabled by default for tokenizers that support it, since this is
+	// the expected HuggingFace tokenizer behavior.
 	AddSpecialTokens bool
 
 	// MaxLen option takes an int value. Set it to a value <= 0 to disable MaxLen.

--- a/tokenizers/bucket/bucket_test.go
+++ b/tokenizers/bucket/bucket_test.go
@@ -133,8 +133,8 @@ func (m *mockTokenizer) SpecialTokenID(token api.SpecialToken) (int, error) {
 }
 
 func (m *mockTokenizer) Normalize(s string) string { return s }
-
-func (m *mockTokenizer) VocabSize() int { return 1000 }
+func (m *mockTokenizer) VocabSize() int            { return 1000 }
+func (m *mockTokenizer) Config() *api.Config       { return nil }
 
 func TestBucketizerRun(t *testing.T) {
 	mockTok := &mockTokenizer{padID: 99}

--- a/tokenizers/hftokenizer/hftokenizer.go
+++ b/tokenizers/hftokenizer/hftokenizer.go
@@ -273,9 +273,6 @@ func (t *Tokenizer) With(options api.EncodeOptions) error {
 	return nil
 }
 
-// Encode converts text to a sequence of token IDs, including post-processing
-// (e.g., [CLS]/[SEP] wrapping for BERT-style models).
-// This matches Python's tokenizer(text) default behavior.
 func (t *Tokenizer) Encode(text string) []int {
 	result := t.encodeCore(text)
 	if t.options.AddSpecialTokens {
@@ -707,6 +704,11 @@ func (t *Tokenizer) GetVocab() map[string]int {
 		vocab[at.Content] = at.ID
 	}
 	return vocab
+}
+
+// Config returns the HuggingFace tokenizer configuration.
+func (t *Tokenizer) Config() *api.Config {
+	return t.config
 }
 
 // Helper functions

--- a/tokenizers/hftokenizer/postprocessor.go
+++ b/tokenizers/hftokenizer/postprocessor.go
@@ -1,26 +1,53 @@
 package hftokenizer
 
-import "github.com/gomlx/go-huggingface/tokenizers/api"
+import (
+	"github.com/gomlx/go-huggingface/tokenizers/api"
+)
 
 // applyPostProcessor applies the post_processor to add special tokens
 // (e.g., [CLS] prefix and [SEP] suffix for BERT-style models).
 // This matches the Rust tokenizer's addSpecialTokens=true behavior.
 //
 // Supported types: TemplateProcessing, BertProcessing, RobertaProcessing.
+// As a fallback, this also injects configured bos/eos tokens from tokenizer_config.json
 func (t *Tokenizer) applyPostProcessor(ids []int, spans []api.TokenSpan) ([]int, []api.TokenSpan, []int) {
+	outIDs := ids
+	outSpans := spans
+	var outSpecial []int
+
 	pp := t.tokenizer.PostProcessor
-	if pp == nil {
-		return ids, spans, nil
+	if pp != nil {
+		switch pp.Type {
+		case "TemplateProcessing":
+			outIDs, outSpans, outSpecial = t.applyTemplateProcessing(pp, ids, spans)
+		case "BertProcessing", "RobertaProcessing":
+			outIDs, outSpans, outSpecial = t.applyBertProcessing(pp, ids, spans)
+		}
 	}
 
-	switch pp.Type {
-	case "TemplateProcessing":
-		return t.applyTemplateProcessing(pp, ids, spans)
-	case "BertProcessing", "RobertaProcessing":
-		return t.applyBertProcessing(pp, ids, spans)
-	default:
-		return ids, spans, nil
+	// Prepare outSpecial mask if it hasn't been instantiated
+	if outSpecial == nil && len(outIDs) > 0 {
+		outSpecial = make([]int, len(outIDs))
 	}
+
+	if t.config != nil {
+		if t.config.AddBosToken && t.bosID >= 0 {
+			if len(outIDs) == 0 || outIDs[0] != t.bosID {
+				outIDs = append([]int{t.bosID}, outIDs...)
+				outSpans = append([]api.TokenSpan{{Start: -1, End: -1}}, outSpans...)
+				outSpecial = append([]int{1}, outSpecial...)
+			}
+		}
+		if t.config.AddEosToken && t.eosID >= 0 {
+			if len(outIDs) == 0 || outIDs[len(outIDs)-1] != t.eosID {
+				outIDs = append(outIDs, t.eosID)
+				outSpans = append(outSpans, api.TokenSpan{Start: -1, End: -1})
+				outSpecial = append(outSpecial, 1)
+			}
+		}
+	}
+
+	return outIDs, outSpans, outSpecial
 }
 
 // applyTemplateProcessing handles TemplateProcessing post-processors.

--- a/tokenizers/sentencepiece/postprocessor.go
+++ b/tokenizers/sentencepiece/postprocessor.go
@@ -1,0 +1,41 @@
+package sentencepiece
+
+import (
+	"github.com/gomlx/go-huggingface/tokenizers/api"
+)
+
+// applyPostProcessor applies the post_processor to add special tokens.
+// It injects configured bos/eos tokens from tokenizer_config.json.
+func (t *Tokenizer) applyPostProcessor(ids []int, spans []api.TokenSpan) ([]int, []api.TokenSpan, []int) {
+	outIDs := ids
+	outSpans := spans
+	var outSpecial []int
+
+	// Prepare outSpecial mask if it hasn't been instantiated
+	if outSpecial == nil && len(outIDs) > 0 {
+		outSpecial = make([]int, len(outIDs))
+	}
+
+	if t.config != nil {
+		if t.config.AddBosToken && t.Info.BeginningOfSentenceID >= 0 {
+			if len(outIDs) == 0 || outIDs[0] != t.Info.BeginningOfSentenceID {
+				outIDs = append([]int{t.Info.BeginningOfSentenceID}, outIDs...)
+				if spans != nil {
+					outSpans = append([]api.TokenSpan{{Start: -1, End: -1}}, outSpans...)
+				}
+				outSpecial = append([]int{1}, outSpecial...)
+			}
+		}
+		if t.config.AddEosToken && t.Info.EndOfSentenceID >= 0 {
+			if len(outIDs) == 0 || outIDs[len(outIDs)-1] != t.Info.EndOfSentenceID {
+				outIDs = append(outIDs, t.Info.EndOfSentenceID)
+				if spans != nil {
+					outSpans = append(outSpans, api.TokenSpan{Start: -1, End: -1})
+				}
+				outSpecial = append(outSpecial, 1)
+			}
+		}
+	}
+
+	return outIDs, outSpans, outSpecial
+}

--- a/tokenizers/sentencepiece/sentencepiece.go
+++ b/tokenizers/sentencepiece/sentencepiece.go
@@ -32,6 +32,7 @@ func New(config *api.Config, repo *hub.Repo) (api.Tokenizer, error) {
 		options: api.EncodeOptions{
 			AddSpecialTokens: true,
 		},
+		config: config,
 	}, nil
 }
 
@@ -40,6 +41,7 @@ type Tokenizer struct {
 	Processor *esentencepiece.Processor
 	Info      *esentencepiece.ModelInfo
 	options   api.EncodeOptions
+	config    *api.Config
 }
 
 // Compile time assert that sentencepiece.Tokenizer implements tokenizers.Tokenizer interface.
@@ -47,13 +49,13 @@ var _ api.Tokenizer = &Tokenizer{}
 
 // Encode returns the text encoded into a sequence of ids.
 // It implements sampler.Vocabulary.
-func (p *Tokenizer) Encode(text string) []int {
-	return p.EncodeWithAnnotations(text).IDs
+func (t *Tokenizer) Encode(text string) []int {
+	return t.EncodeWithAnnotations(text).IDs
 }
 
 // EncodeWithAnnotations returns the encoded text along with requested annotations.
-func (p *Tokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
-	tokens := p.Processor.Encode(text)
+func (t *Tokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
+	tokens := t.Processor.Encode(text)
 	ids := make([]int, len(tokens))
 	spans := make([]api.TokenSpan, len(tokens))
 
@@ -114,25 +116,25 @@ func (p *Tokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
 	res := api.AnnotatedEncoding{
 		IDs: ids,
 	}
-	if p.options.IncludeSpans {
+	if t.options.IncludeSpans {
 		res.Spans = spans
 	}
 	return res
 }
 
 // With applies options to a tokenizer.
-func (p *Tokenizer) With(options api.EncodeOptions) error {
+func (t *Tokenizer) With(options api.EncodeOptions) error {
 	if options.IncludeSpecialTokensMask || options.AddSpecialTokens || options.MaxLen > 0 {
 		return api.ErrNotImplemented
 	}
-	
-	p.options = options
+
+	t.options = options
 	return nil
 }
 
 // Normalize returns the normalization used by the tokenizer (e.g.: BERT lower cases the string)
 // SentencePiece handles normalization internally, but we don't expose it separately.
-func (p *Tokenizer) Normalize(text string) string {
+func (t *Tokenizer) Normalize(text string) string {
 	return text
 }
 
@@ -151,27 +153,31 @@ func findSubstring(s, substr string, start int) int {
 
 // Decode returns the text from a sequence of ids.
 // It implements sampler.Vocabulary.
-func (p *Tokenizer) Decode(ids []int) string {
-	return p.Processor.Decode(ids)
+func (t *Tokenizer) Decode(ids []int) string {
+	return t.Processor.Decode(ids)
 }
 
 // SpecialTokenID returns the token for the given symbol, or an error if not known.
-func (p *Tokenizer) SpecialTokenID(token api.SpecialToken) (int, error) {
+func (t *Tokenizer) SpecialTokenID(token api.SpecialToken) (int, error) {
 	switch token {
 	case api.TokUnknown:
-		return p.Info.UnknownID, nil
+		return t.Info.UnknownID, nil
 	case api.TokPad:
-		return p.Info.PadID, nil
+		return t.Info.PadID, nil
 	case api.TokBeginningOfSentence:
-		return p.Info.BeginningOfSentenceID, nil
+		return t.Info.BeginningOfSentenceID, nil
 	case api.TokEndOfSentence:
-		return p.Info.EndOfSentenceID, nil
+		return t.Info.EndOfSentenceID, nil
 	default:
 		return 0, errors.Errorf("unknown special token: %s (%d)", token, int(token))
 	}
 }
 
 // VocabSize returns the total number of tokens in the vocabulary.
-func (p *Tokenizer) VocabSize() int {
+func (t *Tokenizer) VocabSize() int {
 	return 0 // TODO: implement
+}
+
+func (t *Tokenizer) Config() *api.Config {
+	return t.config
 }

--- a/tokenizers/sentencepiece/sentencepiece.go
+++ b/tokenizers/sentencepiece/sentencepiece.go
@@ -50,71 +50,17 @@ var _ api.Tokenizer = &Tokenizer{}
 // Encode returns the text encoded into a sequence of ids.
 // It implements sampler.Vocabulary.
 func (t *Tokenizer) Encode(text string) []int {
-	return t.EncodeWithAnnotations(text).IDs
+	ids, _, _ := t.encodeCore(text, false)
+	return ids
 }
 
 // EncodeWithAnnotations returns the encoded text along with requested annotations.
 func (t *Tokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
-	tokens := t.Processor.Encode(text)
-	ids := make([]int, len(tokens))
-	spans := make([]api.TokenSpan, len(tokens))
-
-	// Track position in original text by matching token pieces
-	pos := 0
-	for i, tok := range tokens {
-		ids[i] = tok.ID
-		piece := tok.Text
-
-		// SentencePiece uses U+2581 (lower one eighth block) as the space replacement
-		// We need to handle this when matching back to original text
-		matchPiece := piece
-		hasLeadingSpace := false
-		if len(matchPiece) > 0 && matchPiece[0] == '\xe2' && len(matchPiece) >= 3 &&
-			matchPiece[1] == '\x96' && matchPiece[2] == '\x81' {
-			// Remove the U+2581 metaspace character for matching
-			matchPiece = matchPiece[3:]
-			hasLeadingSpace = true
-		}
-
-		// Skip any whitespace in the original text before this token
-		if hasLeadingSpace {
-			for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t' || text[pos] == '\n' || text[pos] == '\r') {
-				pos++
-			}
-		}
-
-		// Find where this piece starts in the original text
-		start := pos
-
-		// Advance position by the length of the actual content
-		if matchPiece == "" {
-			// Empty piece after removing metaspace (token represents just the space)
-			// Check if there was actually a space character
-			if hasLeadingSpace && start > 0 {
-				start = start - 1
-				spans[i] = api.TokenSpan{Start: start, End: pos}
-			} else {
-				spans[i] = api.TokenSpan{Start: pos, End: pos}
-			}
-		} else {
-			// Find the piece in the text starting from current position
-			foundAt := findSubstring(text, matchPiece, pos)
-			if foundAt >= 0 {
-				start = foundAt
-				pos = foundAt + len(matchPiece)
-			} else {
-				// Fallback: advance by piece length
-				pos += len(matchPiece)
-				if pos > len(text) {
-					pos = len(text)
-				}
-			}
-			spans[i] = api.TokenSpan{Start: start, End: pos}
-		}
-	}
+	ids, spans, specialTokensMask := t.encodeCore(text, t.options.IncludeSpans)
 
 	res := api.AnnotatedEncoding{
-		IDs: ids,
+		IDs:               ids,
+		SpecialTokensMask: specialTokensMask,
 	}
 	if t.options.IncludeSpans {
 		res.Spans = spans
@@ -122,9 +68,81 @@ func (t *Tokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
 	return res
 }
 
+func (t *Tokenizer) encodeCore(text string, includeSpans bool) ([]int, []api.TokenSpan, []int) {
+	tokens := t.Processor.Encode(text)
+	ids := make([]int, len(tokens))
+	for i, tok := range tokens {
+		ids[i] = tok.ID
+	}
+
+	var spans []api.TokenSpan
+	if includeSpans {
+		spans = make([]api.TokenSpan, len(tokens))
+
+		// Track position in original text by matching token pieces
+		pos := 0
+		for i, tok := range tokens {
+			piece := tok.Text
+
+			// SentencePiece uses U+2581 (lower one eighth block) as the space replacement
+			// We need to handle this when matching back to original text
+			matchPiece := piece
+			hasLeadingSpace := false
+			if len(matchPiece) > 0 && matchPiece[0] == '\xe2' && len(matchPiece) >= 3 &&
+				matchPiece[1] == '\x96' && matchPiece[2] == '\x81' {
+				// Remove the U+2581 metaspace character for matching
+				matchPiece = matchPiece[3:]
+				hasLeadingSpace = true
+			}
+
+			// Skip any whitespace in the original text before this token
+			if hasLeadingSpace {
+				for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t' || text[pos] == '\n' || text[pos] == '\r') {
+					pos++
+				}
+			}
+
+			// Find where this piece starts in the original text
+			start := pos
+
+			// Advance position by the length of the actual content
+			if matchPiece == "" {
+				// Empty piece after removing metaspace (token represents just the space)
+				// Check if there was actually a space character
+				if hasLeadingSpace && start > 0 {
+					start = start - 1
+					spans[i] = api.TokenSpan{Start: start, End: pos}
+				} else {
+					spans[i] = api.TokenSpan{Start: pos, End: pos}
+				}
+			} else {
+				// Find the piece in the text starting from current position
+				foundAt := findSubstring(text, matchPiece, pos)
+				if foundAt >= 0 {
+					start = foundAt
+					pos = foundAt + len(matchPiece)
+				} else {
+					// Fallback: advance by piece length
+					pos += len(matchPiece)
+					if pos > len(text) {
+						pos = len(text)
+					}
+				}
+				spans[i] = api.TokenSpan{Start: start, End: pos}
+			}
+		}
+	}
+
+	if t.options.AddSpecialTokens {
+		return t.applyPostProcessor(ids, spans)
+	}
+
+	return ids, spans, nil
+}
+
 // With applies options to a tokenizer.
 func (t *Tokenizer) With(options api.EncodeOptions) error {
-	if options.IncludeSpecialTokensMask || options.AddSpecialTokens || options.MaxLen > 0 {
+	if options.IncludeSpecialTokensMask || options.MaxLen > 0 {
 		return api.ErrNotImplemented
 	}
 


### PR DESCRIPTION
This PR introduces several enhancements to the `tokenizers` package:

- Added `Config() *Config` method to the `api.Tokenizer` interface.
- Enhanced `hftokenizer` and `sentencepiece` to support `AddBosToken` and `AddEosToken`.
- Implemented post-processing for the `sentencepiece` tokenizer.
- Updated `CHANGELOG.md` to reflect these changes.