### PR TITLE
Support Batching and Padding (Masking) for Sentence Embeddings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,9 +30,13 @@
     - `RegisteredPromptTasks` returns a list of all task codes for which prompts are registered.
     - `GetTaskPrompt` returns the prompt string for the given task code.
   - `LoadContext` now accepts an optional (nil-lable) backend and loads the variables directly into the backend.
+  - Fixed mask support for batches with padding.
 - Package `safetensors` and `gguf`:
   - `IterTensors` and `IterTensorsFromRepo` now take an optional (nil-lable) backend for reading tensors directly into
     a backend.
+- Examples:
+  - Added [Tecent's KaLM-Gemma3 12B model](https://huggingface.co/tencent/KaLM-Embedding-Gemma3-12B-2511) sentence embedder example.
+  - Added [MSMARCO Dataset](https://huggingface.co/datasets/microsoft/ms_marco) example.
 
 ## v0.3.4
 

--- a/examples/kalmgemma3/kalmgemma3_test.go
+++ b/examples/kalmgemma3/kalmgemma3_test.go
@@ -13,10 +13,12 @@ import (
 	"time"
 
 	"github.com/gomlx/go-huggingface/models/transformer"
+	"github.com/gomlx/go-huggingface/tokenizers/api"
 	"github.com/gomlx/gomlx/backends"
 	_ "github.com/gomlx/gomlx/backends/default"
 	"github.com/gomlx/gomlx/pkg/core/dtypes"
 	"github.com/gomlx/gomlx/pkg/core/graph"
+	"github.com/gomlx/gomlx/pkg/core/shapes"
 	"github.com/gomlx/gomlx/pkg/core/tensors"
 	"github.com/gomlx/gomlx/pkg/ml/context"
 	"github.com/gomlx/gomlx/pkg/support/xslices"
@@ -37,6 +39,7 @@ var (
 	taskPrompts TaskPrompts
 	testQueries []string
 	testDocs    []string
+	testPadID   int32
 )
 
 func must(err error) {
@@ -88,7 +91,15 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	fmt.Printf("✅ Model: %s\n\n", testModel.Description())
+	fmt.Printf("✅ Model: %s", testModel.Description())
+
+	tokenizer := must1(testModel.GetTokenizer())
+	padID, err := tokenizer.SpecialTokenID(api.TokPad)
+	if err != nil {
+		fmt.Printf("Padding token not defined: %+v\n", err)
+		os.Exit(1)
+	}
+	testPadID = int32(padID)
 
 	taskPrompts = must1(LoadTaskPrompts(repo))
 	fmt.Printf("✅ Task prompts loaded: %d tasks\n", len(taskPrompts))
@@ -212,6 +223,7 @@ func TestTransformerLayers(t *testing.T) {
 		{"Doc 2", testDocs[1], "layer_emb_d2.txt"},
 	}
 
+	tokenizer := must1(testModel.GetTokenizer())
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedLayers, err := readPythonEmbeddings(tc.fileName, finalLayersToCheck)
@@ -224,64 +236,107 @@ func TestTransformerLayers(t *testing.T) {
 				}
 			}
 
-			tokensInt := must1(testModel.GetTokenizer()).Encode(tc.prompt)
-			tokens := make([]int32, len(tokensInt))
-			for j, tIdx := range tokensInt {
-				tokens[j] = int32(tIdx)
-			}
-			inputTensor := tensors.FromValue([][]int32{tokens})
-
-			fmt.Printf("- Executing model for %s ...", tc.name)
-			start := time.Now()
-			results, err := exec.Exec(inputTensor)
-			if err != nil {
-				t.Fatalf("Failed to execute graph: %v", err)
-			}
-			fmt.Printf("done (%v)\n", time.Since(start))
-
-			if len(results) < testModel.Config.NumHiddenLayers+1 {
-				t.Fatalf("Expected at least %d outputs from graph, got %d", testModel.Config.NumHiddenLayers+1, len(results))
-			}
-
-			for _, l := range finalLayersToCheck {
-				outTensor := results[l]
-				expectedData := expectedLayers[l]
-				name := fmt.Sprintf("Layer %d Output", l)
-				if l == 0 {
-					name = "Token Embeddings"
-				}
-				outTensor.ConstFlatData(func(flatAny any) {
-					flat := flatAny.([]float32)
-					outShape := outTensor.Shape()
-					if outShape.Rank() < 3 {
-						t.Fatalf("[%s] Expected rank >= 3, got %s", name, outShape)
+			tokens := tokenizer.Encode(tc.prompt)
+			testSubTitle := []string{"no-mask", "with-mask"}
+			for maskIdx, withMask := range []bool{false, true} {
+				t.Run(testSubTitle[maskIdx], func(t *testing.T) {
+					// Create inputTensor with extra padding if mask is selected.
+					sentenceLen := len(tokens)
+					var inputTensor *tensors.Tensor
+					if withMask {
+						sentenceLen += 10 // Extra padding.
 					}
-					batchSize := outShape.Dimensions[1]
-					if batchSize != len(tokens) {
-						t.Fatalf("[%s] Expected %d tokens in output, got %d -- output shape is %s", name, len(tokens), batchSize, outShape)
+					inputTensor = tensors.FromShape(shapes.Make(dtypes.Int32, 1, sentenceLen))
+					tensors.MustMutableFlatData(inputTensor, func(flat []int32) {
+						for i, token := range tokens {
+							flat[i] = int32(token)
+						}
+						if withMask && testPadID != 0 {
+							for i := len(tokens); i < sentenceLen; i++ {
+								flat[i] = testPadID
+							}
+						}
+					})
+
+					// Execute the embedder.
+					fmt.Printf("- Executing model for %s ...", tc.name)
+					start := time.Now()
+					gotAllLayers, err := exec.Exec(inputTensor)
+					if err != nil {
+						t.Fatalf("Failed to execute graph: %v", err)
 					}
-					if outShape.Dimensions[2] != testModel.Config.HiddenSize {
-						t.Fatalf("[%s] Expected hidden size %d, got %d -- output shape is %s", name, testModel.Config.HiddenSize, outShape.Dimensions[2], outShape)
+					fmt.Printf("done (%v)\n", time.Since(start))
+					if len(gotAllLayers) < testModel.Config.NumHiddenLayers+1 {
+						t.Fatalf("Expected at least %d outputs from graph, got %d", testModel.Config.NumHiddenLayers+1, len(gotAllLayers))
 					}
-					validateTensor(t, flat, expectedData, name)
+
+					for _, l := range finalLayersToCheck {
+						gotLayer := gotAllLayers[l]
+						expectedFlat := expectedLayers[l]
+						name := fmt.Sprintf("Layer %d Output", l)
+						if l == 0 {
+							name = "Token Embeddings"
+						}
+
+						// Verify shape of layer.
+						gotShape := gotLayer.Shape()
+						if gotShape.Rank() < 3 {
+							t.Fatalf("[%s] Expected rank >= 3, got %s", name, gotShape)
+						}
+						if gotShape.Dimensions[0] != 1 {
+							t.Fatalf("[%s] Expected batch size 1, got %d -- output shape is %s", name, gotShape.Dimensions[0], gotShape)
+						}
+						gotSentenceLen := gotShape.Dimensions[1]
+						if gotSentenceLen != sentenceLen {
+							t.Fatalf("[%s] Expected %d tokens in output, got %d -- output shape is %s", name, sentenceLen, gotSentenceLen, gotShape)
+						}
+						if gotShape.Dimensions[2] != testModel.Config.HiddenSize {
+							t.Fatalf("[%s] Expected hidden size %d, got %d -- output shape is %s", name, testModel.Config.HiddenSize, gotShape.Dimensions[2], gotShape)
+						}
+
+						// Verify values of the first len(tokens) only, we don't need to check the padding.
+						gotLayer.ConstFlatData(func(flatAny any) {
+							gotFlat := flatAny.([]float32)
+							validateTensor(t, gotFlat, expectedFlat, name, 1, sentenceLen, len(tokens))
+						})
+					}
 				})
 			}
 		})
 	}
 }
 
-func validateTensor(t *testing.T, got []float32, expected []float32, name string) {
-	if len(got) != len(expected) {
-		t.Fatalf("[%s] Shape mismatch: expected %d flat floats (%d tokens), got %d (%d tokens)",
-			name, len(expected), len(expected)/EmbeddingDim, len(got), len(got)/EmbeddingDim)
+// validateTensor validates the values of a tensor.
+// It checks the values of the first expectedSentenceLen tokens only, ignoring the padding in
+// case gotSentencenLen > expectedSentenceLen.
+func validateTensor(t *testing.T, got []float32, expected []float32, name string,
+	batchSize, gotSentenceLen, expectedSentenceLen int) {
+
+	gotHiddenDim := len(got) / batchSize / gotSentenceLen
+	expectedHiddenDim := len(expected) / batchSize / expectedSentenceLen
+	if gotHiddenDim == 0 || gotHiddenDim != expectedHiddenDim || gotSentenceLen < expectedSentenceLen {
+		t.Fatalf("[%s] Shape mismatch: expected %d flat floats ([%d, %d, %d]?), got %d ([%d, %d, %d])",
+			name, len(expected), batchSize, expectedSentenceLen, expectedHiddenDim,
+			len(got), batchSize, gotSentenceLen, gotHiddenDim)
+	}
+
+	// Find mapping from expected indices to got indices.
+	expectedShape := shapes.Make(dtypes.Float32, batchSize, expectedSentenceLen, expectedHiddenDim)
+	gotShape := shapes.Make(dtypes.Float32, batchSize, gotSentenceLen, gotHiddenDim)
+	gotStrides := gotShape.Strides()
+	gotFlatIdxFn := func(indices []int) int {
+		flatIdx := 0
+		for i, idx := range indices {
+			flatIdx += idx * gotStrides[i]
+		}
+		return flatIdx
 	}
 
 	var sumAbsDiff, sumAbsExpected float64
 	const minRelDenominator = 0.2
-	for i, gotValue := range got {
-		expectValue := float64(expected[i])
-		gotValueF64 := float64(gotValue)
-
+	for flatIdx, expectedIndices := range expectedShape.Iter() {
+		expectValue := float64(expected[flatIdx])
+		gotValueF64 := float64(got[gotFlatIdxFn(expectedIndices)])
 		absDiff := math.Abs(gotValueF64 - expectValue)
 		sumAbsDiff += absDiff
 		sumAbsExpected += math.Abs(expectValue)
@@ -291,16 +346,16 @@ func validateTensor(t *testing.T, got []float32, expected []float32, name string
 
 	var maxRelDiff float64
 	var maxRelDiffIdx int
-	for i, gotValue := range got {
-		expectValue := float64(expected[i])
-		gotValueF64 := float64(gotValue)
+	for flatIdx, expectedIndices := range expectedShape.Iter() {
+		expectValue := float64(expected[flatIdx])
+		gotValueF64 := float64(got[gotFlatIdxFn(expectedIndices)])
 		absDiff := math.Abs(gotValueF64 - expectValue)
 		relDenominator := math.Max(math.Abs(expectValue), math.Abs(gotValueF64))
 		relDenominator = max(relDenominator, meanAbsExpected)
 		relDiff := absDiff / relDenominator
 		if relDiff > maxRelDiff {
 			maxRelDiff = relDiff
-			maxRelDiffIdx = i
+			maxRelDiffIdx = flatIdx
 		}
 	}
 
@@ -312,13 +367,13 @@ func validateTensor(t *testing.T, got []float32, expected []float32, name string
 			"Mean abs diff: %.3g (== %.1f%% of the mean absolute values %.3g)",
 			name, maxRelDiff, maxRelDiffIdx, expected[maxRelDiffIdx], got[maxRelDiffIdx],
 			meanAbsDiff, 100*meanAbsDiff/meanAbsExpected, meanAbsExpected)
-		for i, gotValue := range got {
-			expectValue := float64(expected[i])
-			gotValueF64 := float64(gotValue)
-			if i > 10 && i < len(got)-10 {
+		for flatIdx, expectedIndices := range expectedShape.Iter() {
+			expectValue := float64(expected[flatIdx])
+			gotValueF64 := float64(got[gotFlatIdxFn(expectedIndices)])
+			if flatIdx > 10 && flatIdx < len(expected)-10 {
 				continue
 			}
-			fmt.Printf("\t- Value #%d:\tgot %.3g,\t expected %.3g\n", i, gotValueF64, expectValue)
+			fmt.Printf("\t- Value #%d:\tgot %.3g,\t expected %.3g\n", flatIdx, gotValueF64, expectValue)
 		}
 	} else {
 		t.Logf("[%s] Match! Max rel diff: %.3g, Mean abs diff: %.3g (== %.1f%% of %.3g is the mean absolute)",
@@ -368,17 +423,6 @@ func TestSentenceEmbedding(t *testing.T) {
 		t.Fatalf("Failed to create exec: %v", err)
 	}
 
-	fmt.Printf("- Pre-compiling model ...")
-	start := time.Now()
-	dummyTokens := tensors.FromValue([][]int32{{2}})
-	_, err = exec.Exec(dummyTokens)
-	if err != nil {
-		t.Fatalf("Failed to compile graph: %v", err)
-	}
-	fmt.Printf("done (%v)\n", time.Since(start))
-
-	fmt.Printf("- Executing model ...")
-	start = time.Now()
 	hiddenSize := testModel.Config.HiddenSize
 	if len(expectedFlatData) != len(prompts)*hiddenSize {
 		t.Fatalf("Expected %d flat floats from python embeddings, got %d", len(prompts)*hiddenSize, len(expectedFlatData))
@@ -405,14 +449,101 @@ func TestSentenceEmbedding(t *testing.T) {
 		outTensor.ConstFlatData(func(flatAny any) {
 			flat := flatAny.([]float32)
 			expectedData := expectedFlatData[i*hiddenSize : (i+1)*hiddenSize]
-			validateTensor(t, flat, expectedData, fmt.Sprintf("Sentence Embedding %d", i))
+			validateTensor(t, flat, expectedData, fmt.Sprintf("Sentence Embedding %d", i),
+				1, len(tokens), len(tokens))
 		})
 	}
+}
+
+func TestSentenceBatchEmbedding(t *testing.T) {
+	prompts := make([]string, 0, len(testQueries)+len(testDocs))
+	prompts = append(prompts, testQueries...)
+	prompts = append(prompts, testDocs...)
+
+	pythonPath := "similarity_embeddings.txt"
+	expectedFlatData, err := readPythonEmbeddingsList(pythonPath)
+	if err != nil {
+		t.Skipf("Skipping test because %s is not available: %v", pythonPath, err)
+	}
+
+	exec, err := context.NewExec(testBackend, testCtx.Checked(false), func(ctx *context.Context, tokens *graph.Node) *graph.Node {
+		mask := graph.NotEqual(tokens, graph.Const(tokens.Graph(), testPadID))
+		x := testModel.SentenceEmbeddingGraph(ctx, tokens, mask)
+		return graph.ConvertDType(x, dtypes.Float32)
+	})
+	if err != nil {
+		t.Fatalf("Failed to create exec: %v", err)
+	}
+
+	// Tokenize all sentences.
+	tokenizer := must1(testModel.GetTokenizer())
+	var batchTokens [][]int32
+	var maxLen int
+	for _, prompt := range prompts {
+		tokensInt := tokenizer.Encode(prompt)
+		tokens := xslices.Map(tokensInt, func(t int) int32 { return int32(t) })
+		batchTokens = append(batchTokens, tokens)
+		if len(tokens) > maxLen {
+			maxLen = len(tokens)
+		}
+	}
+
+	// Find the paddedLen and create the flat batch with the tokens+padding.
+	paddedLen := int(math.Pow(2, math.Ceil(math.Log2(float64(maxLen)))))
+	var batchFlat []int32
+	totalBatchSize := len(prompts) * paddedLen
+	if testPadID == 0 {
+		batchFlat = make([]int32, totalBatchSize)
+	} else {
+		batchFlat = xslices.SliceWithValue(totalBatchSize, testPadID)
+	}
+	for i, tokens := range batchTokens {
+		offset := i * paddedLen
+		copy(batchFlat[offset:offset+len(tokens)], tokens)
+	}
+	batch := tensors.FromFlatDataAndDimensions(batchFlat, len(prompts), paddedLen)
+	batch.ToDevice(testBackend, 0)
+
+	fmt.Printf("- Pre-compiling model for batch ...")
+	start := time.Now()
+	err = exec.PreCompile(batch)
+	if err != nil {
+		t.Fatalf("Failed to compile graph: %+v", err)
+	}
 	fmt.Printf("done (%v)\n", time.Since(start))
+
+	fmt.Printf("- Executing model ...")
+	hiddenSize := testModel.Config.HiddenSize
+	if len(expectedFlatData) != len(prompts)*hiddenSize {
+		t.Fatalf("Expected %d flat floats from python embeddings, got %d", len(prompts)*hiddenSize, len(expectedFlatData))
+	}
+	start = time.Now()
+	results, err := exec.Exec(batch)
+	fmt.Printf("done (%v)\n", time.Since(start))
+	if err != nil {
+		t.Fatalf("Failed to execute graph for batched prompts: %v", err)
+	}
+
+	outTensor := results[0]
+	outShape := outTensor.Shape()
+	if outShape.Rank() != 2 || outShape.Dimensions[0] != len(prompts) || outShape.Dimensions[1] != hiddenSize {
+		t.Fatalf("Expected shape [batch, hidden_size] ([%d, %d]), got %s", len(prompts), hiddenSize, outShape)
+	}
+
+	outTensor.ConstFlatData(func(flatAny any) {
+		flat := flatAny.([]float32)
+		for i := range prompts {
+			gotData := flat[i*hiddenSize : (i+1)*hiddenSize]
+			expectedData := expectedFlatData[i*hiddenSize : (i+1)*hiddenSize]
+			validateTensor(t, gotData, expectedData, fmt.Sprintf("Sentence Batch Embedding %d", i),
+				1, 1, 1)
+		}
+	})
 }
 
 func TestSimilarity(t *testing.T) {
-	fmt.Printf("Queries: %q\n", testQueries)
+	fmt.Printf("Queries:   %q\n", testQueries)
+	fmt.Printf("Documents: %q\n", testDocs)
 
 	prompts := make([]string, 0, len(testQueries)+len(testDocs))
 	prompts = append(prompts, testQueries...)
@@ -426,12 +557,13 @@ func TestSimilarity(t *testing.T) {
 
 	allEmbeddingsAny := xslices.Map(allEmbeddings, func(t *tensors.Tensor) any { return t })
 	similarities := must1(graph.ExecOnce(testBackend, func(allEmbeddings []*graph.Node) *graph.Node {
-		queryEmbeddings := graph.Concatenate(allEmbeddings[:len(testQueries)], 0)
-		docEmbeddings := graph.Concatenate(allEmbeddings[len(testQueries):], 0)
+		queryEmbeddings := graph.Stack(allEmbeddings[:len(testQueries)], 0)
+		docEmbeddings := graph.Stack(allEmbeddings[len(testQueries):], 0)
 		return testModel.Similarity(queryEmbeddings, docEmbeddings)
 	}, allEmbeddingsAny...))
 	fmt.Printf("Similarities: %v\n", similarities)
 	want := []float32{0.9316, 0.3984, 0.4251, 0.7317}
+	fmt.Printf("- Expected: %v\n", want)
 	got := tensors.MustCopyFlatData[float32](similarities)
 	require.InDeltaSlicef(t, want, got, 1e-2, "Similaries don't match!")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eliben/go-sentencepiece v0.7.0
 	github.com/gofrs/flock v0.13.0
-	github.com/gomlx/gomlx v0.27.3-0.20260331073747-ceb6ad132507
+	github.com/gomlx/gomlx v0.27.3-0.20260402104346-8c577defa432
 	github.com/google/uuid v1.6.0
 	github.com/parquet-go/parquet-go v0.29.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/gomlx/go-xla v0.2.2 h1:2YMzXAcmK8BvqFjRnUHHtE2QwKDEts2tRglcFcKhZj8=
 github.com/gomlx/go-xla v0.2.2/go.mod h1:T2CsL/E90te3k4qpuzlXv2uQU2FmLMLfUsRlAGqKSuI=
-github.com/gomlx/gomlx v0.27.3-0.20260331073747-ceb6ad132507 h1:2VR4p5G13h+jOxCntVzQQs29L7MUgEusK4y8aoeO2gk=
-github.com/gomlx/gomlx v0.27.3-0.20260331073747-ceb6ad132507/go.mod h1:kk+NQXJ8pFrREbC+oJ/s+sMF+q4zjd3t8+/4Ro/6DHM=
+github.com/gomlx/gomlx v0.27.3-0.20260402104346-8c577defa432 h1:Zk8ETYBAsBYwEu5dqOlNcmvkK3xSFsvyHjBsuRtWah0=
+github.com/gomlx/gomlx v0.27.3-0.20260402104346-8c577defa432/go.mod h1:kk+NQXJ8pFrREbC+oJ/s+sMF+q4zjd3t8+/4Ro/6DHM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/models/transformer/model.go
+++ b/models/transformer/model.go
@@ -162,7 +162,6 @@ func (m *Model) Description() string {
 	if m.PoolingConfig != nil {
 		sb.WriteString(" - 1_Pooling/config.json: loaded\n")
 	}
-
 	return sb.String()
 }
 

--- a/models/transformer/sentence.go
+++ b/models/transformer/sentence.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomlx/gomlx/backends"
 	"github.com/gomlx/gomlx/pkg/core/dtypes"
 	"github.com/gomlx/gomlx/pkg/core/graph"
+	"github.com/gomlx/gomlx/pkg/core/shapes"
 	"github.com/gomlx/gomlx/pkg/ml/context"
 	"github.com/gomlx/gomlx/pkg/support/exceptions"
 )
@@ -21,6 +22,17 @@ import (
 // It returns the final pooled embedding (usually [batchSize, embedSize]) for the sentence.
 func (m *Model) SentenceEmbeddingGraph(ctx *context.Context, tokens, mask *graph.Node) *graph.Node {
 	var x *graph.Node
+	// Add a batch axis if not present.
+	if tokens.Rank() == 1 {
+		tokens = graph.ExpandAxes(tokens, 0) // [seqLen] -> [1, seqLen]
+		if mask != nil {
+			mask = graph.ExpandAxes(mask, 0) // [seqLen] -> [1, seqLen]
+		}
+	}
+	if tokens.Rank() != 2 || (mask != nil && mask.Rank() != 2) {
+		exceptions.Panicf("tokens must be [batchSize, seqLen] and mask must be [batchSize, seqLen] or nil, got %v and %v",
+			tokens.Shape(), mask.Shape())
+	}
 
 	for _, mod := range m.Modules {
 		switch mod.Type {
@@ -34,7 +46,7 @@ func (m *Model) SentenceEmbeddingGraph(ctx *context.Context, tokens, mask *graph
 			if x == nil {
 				exceptions.Panicf("pooling module found before transformer module")
 			}
-			x = m.ApplySentencePooling(ctx, x, tokens, mask)
+			x = m.ApplySentencePooling(x, mask)
 
 		case "sentence_transformers.models.Normalize":
 			if x == nil {
@@ -61,7 +73,7 @@ func (m *Model) SentenceEmbeddingGraph(ctx *context.Context, tokens, mask *graph
 		x = lastLayer
 		// and apply default pooling if a pooling config exists
 		if m.PoolingConfig != nil {
-			x = m.ApplySentencePooling(ctx, x, tokens, mask)
+			x = m.ApplySentencePooling(x, mask)
 		}
 	}
 
@@ -72,34 +84,59 @@ func (m *Model) SentenceEmbeddingGraph(ctx *context.Context, tokens, mask *graph
 // No padding, not bucketing, the exec takes as input a single sentence [seqLen] and returns the embedding [embedDim].
 func (m *Model) SingleSentenceEmbeddingExec(backend backends.Backend, ctx *context.Context) (*context.Exec, error) {
 	return context.NewExec(backend, ctx, func(ctx *context.Context, tokens *graph.Node) *graph.Node {
-		return graph.ConvertDType(m.SentenceEmbeddingGraph(ctx, tokens, nil), dtypes.Float32)
+		output := graph.ConvertDType(m.SentenceEmbeddingGraph(ctx, tokens, nil), dtypes.Float32)
+		if output.Rank() == 2 && output.Shape().Dimensions[0] == 1 {
+			// Remove the batch dimension, since we are expecting a single sentence.
+			return graph.Squeeze(output, 0)
+		}
+		return output
 	})
 }
 
 // ApplySentencePooling applies the configured pooling function to the hidden states.
-func (m *Model) ApplySentencePooling(ctx *context.Context, hiddenStates, tokens, mask *graph.Node) *graph.Node {
+//
+// - hiddenStates: [batchSize, seqLen, hiddenSize]
+// - mask: nil or [batchSize, seqLen] of dtype Bool.
+//
+// Returns [batchSize, hiddenSize]
+func (m *Model) ApplySentencePooling(hiddenStates, mask *graph.Node) *graph.Node {
 	if m.PoolingConfig == nil {
 		exceptions.Panicf("no pooling config was loaded for this model")
 	}
 	cfg := m.PoolingConfig
+	g := hiddenStates.Graph()
+	batchSize := hiddenStates.Shape().Dimensions[0]
+	seqLen := hiddenStates.Shape().Dimensions[1]
 
-	if cfg.PoolingModeLastToken {
-		// In Hugging Face, sentence transformers typically use the attention mask to find the last valid token.
-		// Since we don't handle padding explicitly through an attention mask yet, we take the physical
-		// last token in the sequence. For left-padded or unpadded sequences, this is correct.
-		seqLen := hiddenStates.Shape().Dimensions[1]
-		if seqLen == -1 {
-			// If sequence length is unknown at translation time, we could use graph.Shape(hiddenStates)
-			// and graph.Slice dynamically. For simplicity assuming known seq length for now.
-			exceptions.Panicf("PoolingModeLastToken requires sequence length to be known at trace time")
+	switch {
+	case cfg.PoolingModeLastToken:
+		// In Hugging Face, sentence transformers typically use the "attention mask" (the 1D mask, here called simply
+		// mask) to find the last valid token.
+
+		var lastTokenIdx *graph.Node
+		if mask == nil {
+			// If no mask is provided, assume all tokens are valid and take the last one.
+			lastTokenIdx = graph.Scalar(g, dtypes.Int32, seqLen-1)
+			lastTokenIdx = graph.ExpandAxes(lastTokenIdx, 0)              // scalar -> [1]
+			lastTokenIdx = graph.BroadcastPrefix(lastTokenIdx, batchSize) // -> [batchSize, 1]
+		} else {
+			// Find the last token index by finding the last non-zero element in the mask.
+			// mask is [batchSize, seqLen]
+			sequenceIndices := graph.Iota(g, shapes.Make(dtypes.Int32, batchSize, seqLen), 1)
+			validIndices := graph.Where(mask, sequenceIndices, graph.Scalar(g, dtypes.Int32, -1))
+			lastTokenIdx = graph.ReduceAndKeep(validIndices, graph.ReduceMax, 1) // [batchSize, 1]
 		}
-		sliced := graph.Slice(hiddenStates, graph.AxisRange(), graph.AxisRange(seqLen-1, seqLen))
-		return graph.Squeeze(sliced, 1) // [batch, 1, hidden] -> [batch, hidden]
-	}
+		// Create a one-hot mask for the last token.
+		// lastTokenIdx is [batchSize, 1].
+		oneHot := graph.OneHot(lastTokenIdx, seqLen, hiddenStates.DType()) // -> [batchSize, 1, seqLen]
+		oneHot = graph.Squeeze(oneHot, 1)                                  // -> [batchSize, seqLen]
+		oneHot = graph.ExpandAxes(oneHot, -1)                              // -> [batchSize, seqLen, 1]
+		lastTokenEmbeddings := graph.Mul(hiddenStates, oneHot)             // -> [batchSize, seqLen, hiddenDim]
+		return graph.ReduceSum(lastTokenEmbeddings, 1)                     // -> [batchSize, hiddenDim]
 
-	if cfg.PoolingModeMeanTokens {
+	case cfg.PoolingModeMeanTokens:
 		// Plain mean pooling over the sequence tokens (assuming no padding for now).
-		return graph.ReduceMean(hiddenStates, 1)
+		return graph.MaskedReduceMean(hiddenStates, mask, 1) // [batch, hidden]
 	}
 
 	exceptions.Panicf("no supported pooling mode enabled in PoolingConfig: %+v", cfg)

--- a/models/transformer/sentence.go
+++ b/models/transformer/sentence.go
@@ -107,6 +107,7 @@ func (m *Model) ApplySentencePooling(hiddenStates, mask *graph.Node) *graph.Node
 	g := hiddenStates.Graph()
 	batchSize := hiddenStates.Shape().Dimensions[0]
 	seqLen := hiddenStates.Shape().Dimensions[1]
+	// hiddenDim := hiddenStates.Shape().Dimensions[2]
 
 	switch {
 	case cfg.PoolingModeLastToken:
@@ -126,19 +127,19 @@ func (m *Model) ApplySentencePooling(hiddenStates, mask *graph.Node) *graph.Node
 			validIndices := graph.Where(mask, sequenceIndices, graph.Scalar(g, dtypes.Int32, -1))
 			lastTokenIdx = graph.ReduceAndKeep(validIndices, graph.ReduceMax, 1) // [batchSize, 1]
 		}
-		// Create a one-hot mask for the last token.
-		// lastTokenIdx is [batchSize, 1].
-		oneHot := graph.OneHot(lastTokenIdx, seqLen, hiddenStates.DType()) // -> [batchSize, 1, seqLen]
-		oneHot = graph.Squeeze(oneHot, 1)                                  // -> [batchSize, seqLen]
-		oneHot = graph.ExpandAxes(oneHot, -1)                              // -> [batchSize, seqLen, 1]
-		lastTokenEmbeddings := graph.Mul(hiddenStates, oneHot)             // -> [batchSize, seqLen, hiddenDim]
-		return graph.ReduceSum(lastTokenEmbeddings, 1)                     // -> [batchSize, hiddenDim]
+		// Gather the last token embeddings of each example.
+		// Add the batch index to each lastTokenIdx:
+		batchIndices := graph.Iota(g, lastTokenIdx.Shape(), 0)
+		lastTokenIdx = graph.Concatenate([]*graph.Node{batchIndices, lastTokenIdx}, -1)                        // [batchSize, 2]
+		lastTokenEmbeddings := graph.GatherSlices(hiddenStates, []int{0, 1}, lastTokenIdx, []int{1, 1}, false) // [batchSize, 1, 1, hiddenDim]
+		lastTokenEmbeddings = graph.Squeeze(lastTokenEmbeddings, 1, 2)                                         // [batchSize, hiddenDim]
+		return lastTokenEmbeddings
 
 	case cfg.PoolingModeMeanTokens:
 		// Plain mean pooling over the sequence tokens (assuming no padding for now).
 		return graph.MaskedReduceMean(hiddenStates, mask, 1) // [batch, hidden]
 	}
 
-	exceptions.Panicf("no supported pooling mode enabled in PoolingConfig: %+v", cfg)
+	exceptions.Panicf("unsupported pooling mode in PoolingConfig, please add an issue in github.com/gomlx/go-huggingface to add support for it: %+v", cfg)
 	return nil
 }

--- a/models/transformer/sentence_test.go
+++ b/models/transformer/sentence_test.go
@@ -1,0 +1,65 @@
+package transformer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gomlx/go-huggingface/models/transformer"
+	"github.com/gomlx/gomlx/backends"
+	_ "github.com/gomlx/gomlx/backends/default"
+	"github.com/gomlx/gomlx/pkg/core/dtypes"
+	"github.com/gomlx/gomlx/pkg/core/graph"
+	"github.com/gomlx/gomlx/pkg/core/graph/graphtest"
+	"github.com/gomlx/gomlx/pkg/core/shapes"
+)
+
+func TestApplySentencePooling(t *testing.T) {
+	graphtest.TestOfficialBackends(t, func(t *testing.T, backend backends.Backend) {
+		const (
+			MeanPool = 1
+			LastPool = 2
+		)
+		mask := [][]bool{
+			{true, true, true, true},
+			{true, true, true, false},
+		}
+		testCases := []struct {
+			name     string
+			mask     [][]bool
+			poolType int
+			expected [][]float32
+		}{
+			{"mean_pool-no_mask", nil, MeanPool, [][]float32{{2.5, 2.5, 2.5}, {6.5, 6.5, 6.5}}},
+			{"mean_pool-with_mask", mask, MeanPool, [][]float32{{2.5, 2.5, 2.5}, {6, 6, 6}}},
+			{"last_pool-no_mask", nil, LastPool, [][]float32{{4, 4, 4}, {8, 8, 8}}},
+			{"last_pool-with_mask", mask, LastPool, [][]float32{{4, 4, 4}, {7, 7, 7}}},
+		}
+		for _, tc := range testCases {
+			graphtest.RunTestGraphFnWithBackend(t, tc.name, backend,
+				func(g *graph.Graph) (inputs, outputs []*graph.Node) {
+					// [batchSize=2, seqLen=4, hiddenDim=3]
+					hiddenStates := graph.OnePlus(graph.Iota(g, shapes.Make(dtypes.Float32, 2*4, 3), 0))
+					hiddenStates = graph.Reshape(hiddenStates, 2, 4, 3)
+					var mask *graph.Node
+					if tc.mask != nil {
+						mask = graph.Const(g, tc.mask)
+					}
+					m := &transformer.Model{PoolingConfig: &transformer.PoolingConfig{}}
+					switch tc.poolType {
+					case MeanPool:
+						m.PoolingConfig.PoolingModeMeanTokens = true
+					case LastPool:
+						m.PoolingConfig.PoolingModeLastToken = true
+					default:
+						t.Fatalf("unknown pool type %d", tc.poolType)
+					}
+					out := m.ApplySentencePooling(hiddenStates, mask)
+					fmt.Printf("out.shape=%s\n", out.Shape())
+					if mask != nil {
+						return []*graph.Node{hiddenStates, mask}, []*graph.Node{out}
+					}
+					return []*graph.Node{hiddenStates}, []*graph.Node{out}
+				}, []any{tc.expected}, 1e-3)
+		}
+	})
+}


### PR DESCRIPTION
This PR introduces support for batch processing and padding (via masking) when generating sentence embeddings.

Key changes:
- **Refactored `SentenceEmbeddingGraph`** to handle both single sentences and batches, with improved validation for input shapes.
- **Enhanced `ApplySentencePooling`** to respect masks:
    - `PoolingModeLastToken` now correctly identifies the last valid token using the mask via `GatherSlices`.
    - `PoolingModeMeanTokens` now uses `MaskedReduceMean`.
- **Updated `SingleSentenceEmbeddingExec`** to maintain backward compatibility by squeezing the batch dimension for single-sentence inputs.
- **Added comprehensive unit tests** for pooling logic in `models/transformer/sentence_test.go`.
- **Updated `examples/kalmgemma3` tests** to include batched embedding verification and padding/masking scenarios.
- **Updated `gomlx` dependency** to the latest version.