### PR TITLE
Added datasets.CreateParquetReader

### DIFF
--- a/datasets/download.go
+++ b/datasets/download.go
@@ -15,6 +15,8 @@ import (
 
 // ListFiles returns the parquet files that match the given config and split.
 // If config or split are empty, they are not used for filtering.
+//
+// They are returned in the order they are listed in the dataset info.
 func (d *Dataset) ListFiles(config, split string) ([]ParquetFile, error) {
 	allFiles, err := d.GetParquetFiles()
 	if err != nil {

--- a/datasets/parquet.go
+++ b/datasets/parquet.go
@@ -57,6 +57,52 @@ func IterParquetFromFile[T any](filePath string) iter.Seq2[T, error] {
 	}
 }
 
+// CreateParquetReader creates a parquet reader for the given dataset, config and split.
+// This is more flexible than an iterator because it allows for random reads.
+//
+// It groups together all the files for the given config and split and creates a single reader for them.
+// It will fix the schema to match the given type T.
+func CreateParquetReader[T any](ds *Dataset, config, split string) (*parquet.GenericReader[T], error) {
+	filesSelection, err := ds.ListFiles(config, split)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get parquet files info for dataset")
+	}
+	downloadedPaths, err := ds.DownloadCtx(context.Background(), filesSelection...)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to download parquet files for dataset")
+	}
+
+	// Fix the schema first
+	fixedSchema, err := ParquetFixListSchema[T](downloadedPaths[0])
+	if err != nil {
+		return nil, err
+	}
+	if klog.V(1).Enabled() {
+		klog.Infof("Fixed schema: %s\n\n", fixedSchema)
+	}
+
+	// Open each file and append them as "rowGroup"
+	var rowGroups []parquet.RowGroup
+	for _, filePath := range downloadedPaths {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to open %q", filePath)
+		}
+		stat, err := f.Stat()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to stat %q", filePath)
+		}
+		pf, err := parquet.OpenFile(f, stat.Size())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to open parquet from %q", filePath)
+		}
+		rowGroups = append(rowGroups, pf.RowGroups()...)
+	}
+	multiGroup := parquet.MultiRowGroup(rowGroups...)
+	reader := parquet.NewGenericRowGroupReader[T](multiGroup, fixedSchema)
+	return reader, nil
+}
+
 // IterParquetFromDataset downloads all Parquet files associated with the dataset's config and split
 // and iterates over all their records sequentially.
 // It will yield an error and stop if there's an issue acquiring or reading the files.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@
   - Added `cmd/generate_dataset_structs` for generating Go structs for dataset records.
   - Added `ParquetFixListSchema` for fixing list schema parsed from Go struct (a bug? in parquet-go where it hard-codes
     the group/element node names in lists).
+  - Added `CreateParquetReader` for creating a parquet reader for the given dataset, config and split.
+    Less convenient than an iterator, but allows for random access.
 - Package `transformer`
   - Renamed main method to `AllLayers`: it returns both the final hidden state and all layer outputs; 
     it added RoPE positional embeddings support; added support for scaling factor.


### PR DESCRIPTION
This PR introduces `datasets.CreateParquetReader` to the `datasets` package.

### Summary
- Added `CreateParquetReader[T any](ds *Dataset, config, split string) (*parquet.GenericReader[T], error)`:
  - This function groups all Parquet files for a given config and split.
  - It downloads the files if necessary.
  - It creates a single reader for them by combining the row groups.
  - It also fixes the schema based on the generic type `T`.
- Updated `ListFiles` documentation to clarify the order of returned files.
- Updated `docs/CHANGELOG.md`.

This is useful when random access or more flexibility than sequential iteration is required.