### PR TITLE
feat: humanize log and test output messages

### DIFF
--- a/examples/BAAI-bge-small-en-v1.5/bge_test.go
+++ b/examples/BAAI-bge-small-en-v1.5/bge_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
+	"github.com/gomlx/compute/support/humanize"
 	"github.com/gomlx/go-huggingface/hub"
 	hftesting "github.com/gomlx/go-huggingface/internal/testing"
 	"github.com/gomlx/go-huggingface/models/transformer"
@@ -117,7 +118,7 @@ func TestMain(m *testing.M) {
 		for range 3 {
 			runtime.GC()
 		}
-		fmt.Printf("\r✅ Loading model weights: done (%v)\n", time.Since(start))
+		fmt.Printf("\r✅ Loading model weights: done (%s)\n", humanize.Duration(time.Since(start)))
 	}
 
 	// Run the tests

--- a/examples/kalmgemma3/kalmgemma3_test.go
+++ b/examples/kalmgemma3/kalmgemma3_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/shapes"
+	"github.com/gomlx/compute/support/humanize"
 	"github.com/gomlx/compute/support/xslices"
 	"github.com/gomlx/go-huggingface/hub"
 	hftesting "github.com/gomlx/go-huggingface/internal/testing"
@@ -126,7 +127,7 @@ func TestMain(m *testing.M) {
 		for range 3 {
 			runtime.GC()
 		}
-		fmt.Printf("\r✅ Loading model weights: done (%v)\n", time.Since(start))
+		fmt.Printf("\r✅ Loading model weights: done (%v)\n", humanize.Duration(time.Since(start)))
 	}
 
 	// Run the tests
@@ -414,22 +415,22 @@ func TestSentenceBatchEmbedding(t *testing.T) {
 	batch := tensors.FromFlatDataAndDimensions(batchFlat, len(prompts), paddedLen)
 	batch.ToDevice(testBackend, 0)
 
-	fmt.Printf("- Pre-compiling model for batch ...")
+	fmt.Printf(" - Pre-compiling model ...")
 	start := time.Now()
 	err = exec.PreCompile(batch)
 	if err != nil {
 		t.Fatalf("Failed to compile graph: %+v", err)
 	}
-	fmt.Printf("done (%v)\n", time.Since(start))
+	fmt.Printf("\r✅ Pre-compiling model: done (%s)\n", humanize.Duration(time.Since(start)))
 
-	fmt.Printf("- Executing model ...")
+	fmt.Printf(" - Executing model ... ")
 	hiddenSize := testModel.Config.HiddenSize
 	if len(expectedFlatData) != len(prompts)*hiddenSize {
 		t.Fatalf("Expected %d flat floats from python embeddings, got %d", len(prompts)*hiddenSize, len(expectedFlatData))
 	}
 	start = time.Now()
 	results, err := exec.Exec(batch)
-	fmt.Printf("done (%v)\n", time.Since(start))
+	fmt.Printf("\r✅ Executing model: done (%s)\n", humanize.Duration(time.Since(start)))
 	if err != nil {
 		t.Fatalf("Failed to execute graph for batched prompts: %v", err)
 	}

--- a/models/transformer/model.go
+++ b/models/transformer/model.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/support/humanize"
 	"github.com/gomlx/compute/support/xslices"
 	"github.com/gomlx/go-huggingface/hub"
 	"github.com/gomlx/go-huggingface/models/safetensors"
 	"github.com/gomlx/go-huggingface/tokenizers"
 	"github.com/gomlx/gomlx/ml/model"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 )
 
 // Model holds all the configuration loaded about the model.
@@ -146,7 +148,8 @@ func (m *Model) LoadStoreFiltered(backend compute.Backend, store *model.Store, f
 		subScope.VariableWithValue(varName, tensorToLoad)
 	}
 
-	fmt.Printf("\n--> LoadStoreFiltered: Loaded %d parameters (%d bytes)\n", totalParams, totalBytes)
+	klog.V(1).Infof("LoadStoreFiltered: Loaded %s parameters (%s bytes)",
+		humanize.Count(totalParams), humanize.Bytes(totalBytes))
 	m.totalParameters = &totalParams
 	m.totalBytes = &totalBytes
 	return nil


### PR DESCRIPTION
This PR improves the readability of logs and test output messages by formatting durations, counts, and sizes using the `humanize` package. It also transitions a stdout print in the transformer model loader to a structured `klog` statement.

### Key Changes:
- **Duration Formatting**:
  - Replaced raw `time.Duration` printouts with `humanize.Duration(...)` in the `BAAI-bge-small-en-v1.5` and `kalmgemma3` example test suites.
- **Visual Improvements**:
  - Refactored test output status updates in `kalmgemma3_test.go` to use cleaner messages with emoji symbols (e.g., `✅ Pre-compiling model: done (...)`).
- **Structured Logging**:
  - Replaced a `fmt.Printf` log in `models/transformer/model.go` with `klog.V(1).Infof(...)` for parameter loading details.
  - Used `humanize.Count(...)` and `humanize.Bytes(...)` to format the total parameter count and size in bytes respectively.