### PR TITLE
Add Dataset.DownloadAll to pre-download parquet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,27 @@ Config: sample-350BT
   Splits: train (518.5M records, 1.4 TiB)
 ```
 
+### Dataset Downloading Tool
+
+The `./cmd/dataset_download` tool can be used to manage dataset downloads: it downloads, lists (`-list`) and deletes
+(`-delete`) downloaded files.
+
+```
+$ go run ./cmd/dataset_download microsoft/ms_marco
+Retrieving information for dataset "microsoft/ms_marco"...
+
+Available configurations/splits for "microsoft/ms_marco":
+  -config v1.1                      -split test            (1 files, total size: 19.5 MiB)
+  -config v1.1                      -split train           (1 files, total size: 167.3 MiB)
+  -config v1.1                      -split validation      (1 files, total size: 20.4 MiB)
+  -config v2.1                      -split test            (1 files, total size: 194.9 MiB)
+  -config v2.1                      -split train           (7 files, total size: 1.6 GiB)
+  -config v2.1                      -split validation      (1 files, total size: 199.9 MiB)
+```
+
 ### Parquet Structure 
 
-We use the `github.com/gomlx/go-huggingface/cmd/generate_dataset_structs` to generate the Go 
-structure for the Parquet files:
+The `./cmd/generate_dataset_structs` tool generates Go `struct`s to read the Parquet files for a dataset:
 
 ```bash
 go run ./cmd/generate_dataset_structs -dataset HuggingFaceFW/fineweb

--- a/cmd/dataset_download/main.go
+++ b/cmd/dataset_download/main.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"cmp"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/gomlx/compute/support/humanize"
+	"github.com/gomlx/go-huggingface/datasets"
+	"k8s.io/klog/v2"
+)
+
+var (
+	datasetFlag = flag.String("dataset", "", "HuggingFace dataset ID, e.g. \"HuggingFaceFW/fineweb\"")
+	configFlag  = flag.String("config", "", "Dataset configuration. If empty, lists available configs/splits. "+
+		"Set to \"*\" to include all configs.")
+	splitFlag = flag.String("split", "", "Dataset split (e.g. \"train\", \"validation\"). "+
+		"If empty, lists available configs/splits. Set to \"*\" to include all splits.")
+	listFlag      = flag.Bool("list", false, "List downloaded local cache files matching -config and -split instead of downloading")
+	deleteFlag    = flag.Bool("delete", false, "Delete local cache files matching -config and -split instead of downloading")
+	verbosityFlag = flag.Int("verbosity", 1, "Verbosity level for download progress")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags] [dataset_id]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Example: %s -config default -split train HuggingFaceFW/fineweb\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	// Parse dataset ID from flag or positional argument
+	datasetID := *datasetFlag
+	if datasetID == "" && flag.NArg() > 0 {
+		datasetID = flag.Arg(0)
+	}
+
+	if datasetID == "" {
+		fmt.Fprintf(os.Stderr, "Error: missing dataset ID.\n\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Initialize dataset
+	hfAuthToken := os.Getenv("HF_TOKEN")
+	ds := datasets.New(datasetID).WithAuth(hfAuthToken)
+	ds.Verbosity = *verbosityFlag
+
+	config := *configFlag
+	if config == "*" {
+		config = ""
+	}
+	split := *splitFlag
+	if split == "*" {
+		split = ""
+	}
+
+	if *listFlag {
+		listDownloadedFiles(ds, config, split)
+		return
+	}
+
+	// Delete requires both config and split to be explicitly set (even if to "*")
+	if *deleteFlag && (*configFlag == "" || *splitFlag == "") {
+		fmt.Fprintf(os.Stderr, "Error: when using -delete, you must explicitly specify both -config and -split (use \"*\" to match all).\n")
+		os.Exit(1)
+	}
+
+	if *deleteFlag {
+		deleteLocalCache(ds, config, split)
+		return
+	}
+
+	// If the user doesn't set a -config or a -split, list the available configs/splits
+	if *configFlag == "" || *splitFlag == "" {
+		listConfigsAndSplits(ds)
+		return
+	}
+
+	// Both config and split are provided. Download all files
+	ctx := context.Background()
+	fmt.Printf("Downloading files for dataset %q, config %q, split %q...\n", datasetID, *configFlag, *splitFlag)
+	downloadedPaths, err := ds.DownloadAll(ctx, config, split)
+	if err != nil {
+		klog.Fatalf("Error downloading files: %+v", err)
+	}
+
+	fmt.Printf("\nSuccessfully downloaded %d files:\n", len(downloadedPaths))
+	for _, p := range downloadedPaths {
+		fmt.Printf("  - %s\n", p)
+	}
+}
+
+type ConfigSplit struct {
+	Config string
+	Split  string
+}
+
+type GroupInfo struct {
+	Config string
+	Split  string
+	Count  int
+	Size   int64
+}
+
+func listConfigsAndSplits(ds *datasets.Dataset) {
+	fmt.Printf("Retrieving information for dataset %q...\n", ds.ID)
+
+	parquetFiles, err := ds.GetParquetFiles()
+	if err != nil {
+		klog.Fatalf("Error retrieving parquet files: %+v", err)
+	}
+
+	if len(parquetFiles) == 0 {
+		fmt.Printf("No files found for dataset %q.\n", ds.ID)
+		return
+	}
+
+	// Group files by config and split
+	groupsMap := make(map[ConfigSplit]*GroupInfo)
+	for _, f := range parquetFiles {
+		key := ConfigSplit{Config: f.Config, Split: f.Split}
+		gi, exists := groupsMap[key]
+		if !exists {
+			gi = &GroupInfo{
+				Config: f.Config,
+				Split:  f.Split,
+			}
+			groupsMap[key] = gi
+		}
+		gi.Count++
+		gi.Size += f.Size
+	}
+
+	// Sort groups by Config, then by Split
+	var groups []*GroupInfo
+	for _, gi := range groupsMap {
+		groups = append(groups, gi)
+	}
+	slices.SortFunc(groups, func(a, b *GroupInfo) int {
+		if a.Config != b.Config {
+			return cmp.Compare(a.Config, b.Config)
+		}
+		return cmp.Compare(a.Split, b.Split)
+	})
+
+	fmt.Printf("\nAvailable configurations/splits for %q:\n", ds.ID)
+	for _, gi := range groups {
+		fmt.Printf("  -config %-25s -split %-15s (%d files, total size: %s)\n",
+			gi.Config,
+			gi.Split,
+			gi.Count,
+			humanize.Bytes(uint64(gi.Size)),
+		)
+	}
+}
+
+func deleteLocalCache(ds *datasets.Dataset, config, split string) {
+	fmt.Printf("Locating local files for dataset %q, config %q, split %q to delete...\n",
+		ds.ID,
+		cmp.Or(config, "*"),
+		cmp.Or(split, "*"),
+	)
+
+	localFiles, err := ds.ListDownloadedFiles(config, split)
+	if err != nil {
+		klog.Fatalf("Error listing local files: %+v", err)
+	}
+
+	if len(localFiles) == 0 {
+		fmt.Println("No local cache files found matching the criteria.")
+		return
+	}
+
+	deletedCount := 0
+	var deletedBytes int64
+
+	for _, destPath := range localFiles {
+		if fi, err := os.Stat(destPath); err == nil {
+			err = os.Remove(destPath)
+			if err != nil {
+				klog.Warningf("Failed to delete %q: %v", destPath, err)
+			} else {
+				deletedCount++
+				deletedBytes += fi.Size()
+				fmt.Printf("Deleted: %s\n", destPath)
+			}
+		}
+	}
+
+	if deletedCount > 0 {
+		fmt.Printf("\nSuccessfully deleted %d files (freed %s).\n",
+			deletedCount,
+			humanize.Bytes(uint64(deletedBytes)),
+		)
+	} else {
+		fmt.Println("No local cache files were deleted.")
+	}
+}
+
+func listDownloadedFiles(ds *datasets.Dataset, config, split string) {
+	fmt.Printf("Locating local cached files for dataset %q, config %q, split %q...\n",
+		ds.ID,
+		cmp.Or(config, "*"),
+		cmp.Or(split, "*"),
+	)
+
+	localFiles, err := ds.ListDownloadedFiles(config, split)
+	if err != nil {
+		klog.Fatalf("Error listing local files: %+v", err)
+	}
+
+	if len(localFiles) == 0 {
+		fmt.Println("No local cache files found matching the criteria.")
+		return
+	}
+
+	fmt.Printf("\nDownloaded files:\n")
+	var totalSize int64
+	for _, destPath := range localFiles {
+		sizeStr := "-"
+		if fi, err := os.Stat(destPath); err == nil {
+			sizeStr = humanize.Bytes(uint64(fi.Size()))
+			totalSize += fi.Size()
+		}
+		fmt.Printf("  - %s (%s)\n", destPath, sizeStr)
+	}
+	fmt.Printf("\nTotal files: %d, total size: %s\n", len(localFiles), humanize.Bytes(uint64(totalSize)))
+}

--- a/cmd/generate_dataset_structs/main.go
+++ b/cmd/generate_dataset_structs/main.go
@@ -202,7 +202,7 @@ func fallbackLocateAndDownloadParquet(dataset string) (localPath string, rootStr
 	}
 
 	fmt.Printf("[INFO] Found %d parquet files in repository.\n", len(parquetFiles))
-	
+
 	if len(parquetFiles) > 10 {
 		fmt.Printf("[INFO] There are %d parquet files in the repository. We automatically picked file %s\n",
 			len(parquetFiles),
@@ -260,71 +260,71 @@ func highlightGoCode(code string) string {
 	if !*colorFlag {
 		return code
 	}
-	
-	styleKeyword  := lipgloss.NewStyle().Foreground(lipgloss.Color("204")).Bold(true) // Magenta for keywords
-	styleStruct   := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)  // Blue for structs
-	styleField    := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))            // White for fields
-	styleType     := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))            // Green for types
-	styleTagKey   := lipgloss.NewStyle().Foreground(lipgloss.Color("215"))            // Orange/Yellow for tag names
-	styleTagValue := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))            // Cyan for tag values
-	stylePunct    := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))            // Muted gray for symbols
-	styleComment  := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true) // Gray italic for comments
-	
+
+	styleKeyword := lipgloss.NewStyle().Foreground(lipgloss.Color("204")).Bold(true)   // Magenta for keywords
+	styleStruct := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)     // Blue for structs
+	styleField := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))                // White for fields
+	styleType := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))                 // Green for types
+	styleTagKey := lipgloss.NewStyle().Foreground(lipgloss.Color("215"))               // Orange/Yellow for tag names
+	styleTagValue := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))             // Cyan for tag values
+	stylePunct := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))                // Muted gray for symbols
+	styleComment := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true) // Gray italic for comments
+
 	lines := strings.Split(code, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
 		}
-		
+
 		if strings.HasPrefix(trimmed, "//") {
 			lines[i] = styleComment.Render(line)
 			continue
 		}
-		
+
 		if strings.HasPrefix(trimmed, "package ") {
 			packageName := strings.TrimPrefix(trimmed, "package ")
 			packageName = strings.TrimSpace(packageName)
 			lines[i] = styleKeyword.Render("package") + " " + packageName
 			continue
 		}
-		
+
 		if strings.HasPrefix(trimmed, "type ") && strings.HasSuffix(trimmed, " struct {") {
 			structName := strings.TrimPrefix(trimmed, "type ")
 			structName = strings.TrimSuffix(structName, " struct {")
 			structName = strings.TrimSpace(structName)
-			
+
 			indent := len(line) - len(strings.TrimLeft(line, " \t"))
 			indentStr := line[:indent]
-			
+
 			lines[i] = indentStr + styleKeyword.Render("type") + " " +
 				styleStruct.Render(structName) + " " +
 				styleKeyword.Render("struct") + " " +
 				stylePunct.Render("{")
 			continue
 		}
-		
+
 		if trimmed == "}" {
 			indent := len(line) - len(strings.TrimLeft(line, " \t"))
 			indentStr := line[:indent]
 			lines[i] = indentStr + stylePunct.Render("}")
 			continue
 		}
-		
+
 		if strings.Contains(line, "`") {
 			parts := strings.SplitN(line, "`", 2)
 			fieldAndType := parts[0]
 			tags := parts[1]
-			
+
 			indent := len(fieldAndType) - len(strings.TrimLeft(fieldAndType, " \t"))
 			indentStr := fieldAndType[:indent]
 			fieldAndTypeTrim := strings.TrimSpace(fieldAndType)
-			
+
 			ftParts := strings.SplitN(fieldAndTypeTrim, " ", 2)
 			if len(ftParts) == 2 {
 				fieldName := ftParts[0]
 				fieldType := ftParts[1]
-				
+
 				tags = strings.TrimSuffix(tags, "`")
 				tagPairs := strings.Split(tags, " ")
 				var styledTagPairs []string
@@ -334,12 +334,12 @@ func highlightGoCode(code string) string {
 						k := kv[0]
 						v := kv[1]
 						styledTagPairs = append(styledTagPairs,
-							styleTagKey.Render(k) + stylePunct.Render(":") + styleTagValue.Render(v))
+							styleTagKey.Render(k)+stylePunct.Render(":")+styleTagValue.Render(v))
 					} else {
 						styledTagPairs = append(styledTagPairs, pair)
 					}
 				}
-				
+
 				lines[i] = indentStr +
 					styleField.Render(fieldName) + " " +
 					styleType.Render(fieldType) + " " +

--- a/datasets/download.go
+++ b/datasets/download.go
@@ -198,3 +198,25 @@ func (ds *Dataset) DownloadAll(ctx context.Context, config, split string) (downl
 	}
 	return ds.DownloadCtx(ctx, remoteFiles...)
 }
+
+// ListDownloadedFiles returns the list of absolute paths to the parquet files that match the given config and split
+// and exist in the local cache.
+// If config or split are empty, they are not used for filtering.
+func (d *Dataset) ListDownloadedFiles(config, split string) ([]string, error) {
+	repoCacheDir, err := d.CacheDir()
+	if err != nil {
+		return nil, err
+	}
+	allFiles, err := d.ListFiles(config, split)
+	if err != nil {
+		return nil, err
+	}
+	var res []string
+	for _, f := range allFiles {
+		destPath := path.Join(repoCacheDir, "parquet", f.Config, f.Split, f.Filename)
+		if files.Exists(destPath) {
+			res = append(res, destPath)
+		}
+	}
+	return res, nil
+}

--- a/datasets/download.go
+++ b/datasets/download.go
@@ -184,3 +184,17 @@ func (d *Dataset) DownloadCtx(ctx context.Context, parquetFiles ...ParquetFile) 
 	}
 	return downloadedPaths, nil
 }
+
+// DownloadAll for the given config/split. It will download all the files into the cache,
+// which can then be iterated over (without any downloads).
+//
+// If config or split are empty, they are not used for filtering.
+//
+// It returns the list of the paths to the downloaded files in the cache.
+func (ds *Dataset) DownloadAll(ctx context.Context, config, split string) (downloadedPaths []string, err error) {
+	remoteFiles, err := ds.ListFiles(config, split)
+	if err != nil {
+		return nil, err
+	}
+	return ds.DownloadCtx(ctx, remoteFiles...)
+}

--- a/datasets/info_test.go
+++ b/datasets/info_test.go
@@ -79,3 +79,20 @@ func TestDatasetListFilesFineweb(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, files, "Should find parquet files for sample-10BT config")
 }
+
+func TestListDownloadedFiles(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping network tests in CI")
+	}
+
+	ds := New("microsoft/ms_marco")
+
+	// Ensure the files are downloaded first.
+	_, err := ds.DownloadAll(context.Background(), "v1.1", "test")
+	require.NoError(t, err)
+
+	downloaded, err := ds.ListDownloadedFiles("v1.1", "test")
+	require.NoError(t, err)
+	assert.NotEmpty(t, downloaded, "Should find downloaded files for config v1.1 and split test")
+}
+

--- a/datasets/parquet.go
+++ b/datasets/parquet.go
@@ -105,6 +105,9 @@ func CreateParquetReader[T any](ds *Dataset, config, split string) (*parquet.Gen
 
 // IterParquetFromDataset downloads Parquet files associated with the dataset's config and split
 // on demand (one by one) and iterates over all their records sequentially.
+//
+// If you want to pre-download all the parquet files for a dataset/config/split, use DownloadAll.
+//
 // It will yield an error and stop if there's an issue acquiring or reading the files.
 func IterParquetFromDataset[T any](ds *Dataset, config, split string) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 )
 
 tool github.com/gomlx/go-huggingface/cmd/generate_dataset_structs
+
+tool github.com/gomlx/go-huggingface/cmd/dataset_download


### PR DESCRIPTION
This PR adds the `Dataset.DownloadAll` method to pre-download all files for a given config/split of a HuggingFace dataset into the cache, along with a command-line tool to download, list, and delete cache files.

### Changes
* **[`datasets/download.go`](file:///home/janpf/Projects/gomlx/go-huggingface/datasets/download.go)**:
  - Added `DownloadAll(ctx context.Context, config, split string)` which retrieves all remote files via `ListFiles` and downloads them concurrently using `DownloadCtx`.
  - Added `ListDownloadedFiles(config, split string)` to query local cached file paths.
* **[`datasets/parquet.go`](file:///home/janpf/Projects/gomlx/go-huggingface/datasets/parquet.go)**: Updated docstring of `IterParquetFromDataset` to reference `DownloadAll` for pre-downloading files before iteration.
* **[`cmd/dataset_download`](file:///home/janpf/Projects/gomlx/go-huggingface/cmd/dataset_download/main.go)**: Created a new CLI tool to download, delete (`-delete`), or list (`-list`) local cached files for a dataset, support wildcard `*`, and list available configs/splits when parameters are unset.
* **[`go.mod`](file:///home/janpf/Projects/gomlx/go-huggingface/go.mod)**: Registered `cmd/dataset_download` in the native Go `tool` directive.
