### PR TITLE
Move temporary file download logic to downloader.Download and modernize sync.WaitGroup usage

### DIFF
--- a/datasets/download.go
+++ b/datasets/download.go
@@ -130,20 +130,17 @@ func (d *Dataset) DownloadCtx(ctx context.Context, parquetFiles ...ParquetFile) 
 			return nil, errors.Wrapf(err, "while creating directory to download %q", destPath)
 		}
 
-		wg.Add(1)
-		go func(idx int, pf ParquetFile, destPath string) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			downloadingMu.Lock()
 			requireDownload++
 			downloadingMu.Unlock()
 			err := downloadManager.LockedDownload(ctx, pf.URL, destPath, false, func(downloadedBytes, totalBytes int64) {
 				downloadingMu.Lock()
 				defer downloadingMu.Unlock()
-				lastReportedBytes := perFileDownloaded[idx]
+				lastReportedBytes := perFileDownloaded[idxFile]
 				newDownloaded := uint64(downloadedBytes) - lastReportedBytes
 				allFilesDownloaded += newDownloaded
-				perFileDownloaded[idx] = uint64(downloadedBytes)
+				perFileDownloaded[idxFile] = uint64(downloadedBytes)
 				if d.Verbosity > 0 && time.Since(lastPrintTime) > time.Second {
 					ratePrintFn()
 				}
@@ -160,7 +157,7 @@ func (d *Dataset) DownloadCtx(ctx context.Context, parquetFiles ...ParquetFile) 
 				ratePrintFn()
 			}
 			downloadingMu.Unlock()
-		}(idxFile, pf, destPath)
+		})
 	}
 	wg.Wait()
 

--- a/hub/files.go
+++ b/hub/files.go
@@ -221,10 +221,7 @@ func (r *Repo) DownloadFilesCtx(ctx context.Context, repoFiles ...string) (downl
 		}
 
 		// Start downloading in a separate goroutine.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			// Download header of file for safety checks, and so we can find the blobPath.
 			header, contentLength, err := downloadManager.FetchHeader(ctx, fileURL)
 			if err != nil {
@@ -278,7 +275,7 @@ func (r *Repo) DownloadFilesCtx(ctx context.Context, repoFiles ...string) (downl
 			if err != nil {
 				reportErrorFn(errors.WithMessagef(err, "while downloading %q from repository %q", repoFileName, r.ID))
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	if requireDownload > 0 {

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -17,6 +17,9 @@ import (
 	"github.com/gomlx/go-huggingface/internal/files"
 )
 
+// Part is the file extension used for temporary files during download.
+const Part = "part"
+
 // ProgressCallback is called as download progresses.
 //   - totalBytes may be set to 0 if total size is not yet known.
 type ProgressCallback func(downloadedBytes, totalBytes int64)
@@ -74,6 +77,10 @@ func (m *Manager) setRequestHeader(req *http.Request) {
 // Progress of download is reported back to the given callback, if not nil.
 //
 // The context ctx can be used to interrupt the downloading.
+//
+// Note: this download files with a ".part" suffix (Part) first, and moves the file to filePath only after
+// the download has completed successfully. This way, if the download is interrupted, the
+// final file will not be present, and a re-run will download the file from scratch.
 func (m *Manager) Download(ctx context.Context, url string, filePath string, callback ProgressCallback) error {
 	m.semaphore.Acquire()
 	defer m.semaphore.Release()
@@ -93,14 +100,19 @@ func (m *Manager) Download(ctx context.Context, url string, filePath string, cal
 	if err = os.MkdirAll(path.Dir(filePath), 0777); err != nil {
 		return errors.Wrapf(err, "Failed to create the directory for the path: %q", path.Dir(filePath))
 	}
+	filePathPart := filePath + "." + Part
 	var file *os.File
-	file, err = os.Create(filePath)
+	file, err = os.Create(filePathPart)
 	if err != nil {
-		return errors.Wrapf(err, "failed creating file %q", filePath)
+		return errors.Wrapf(err, "failed creating file %q", filePathPart)
 	}
+	var downloadSuccess bool
 	defer func() {
 		if file != nil {
 			_ = file.Close()
+		}
+		if !downloadSuccess {
+			_ = os.Remove(filePathPart)
 		}
 	}()
 
@@ -153,11 +165,11 @@ func (m *Manager) Download(ctx context.Context, url string, filePath string, cal
 		if n > 0 {
 			wn, writeErr := file.Write(buf[:n])
 			if writeErr != nil && writeErr != io.EOF {
-				return errors.Wrapf(writeErr, "failed writing %q to %q", url, filePath)
+				return errors.Wrapf(writeErr, "failed writing %q to %q", url, filePathPart)
 			}
 			if wn != n {
 				return errors.Wrapf(io.ErrShortWrite, "failed writing %q to %q: not enough bytes written (wanted %d, wrote only %d)",
-					url, filePath, n, wn)
+					url, filePathPart, n, wn)
 			}
 		}
 		if readErr == io.EOF {
@@ -171,11 +183,15 @@ func (m *Manager) Download(ctx context.Context, url string, filePath string, cal
 	err = file.Close()
 	file = nil
 	if err != nil {
-		return errors.Wrapf(err, "failed closing file %q", filePath)
+		return errors.Wrapf(err, "failed closing file %q", filePathPart)
 	}
 	if err = resp.Body.Close(); err != nil {
 		return errors.Wrapf(err, "failed closing connection to %q", url)
 	}
+	if err = os.Rename(filePathPart, filePath); err != nil {
+		return errors.Wrapf(err, "failed moving %q to %q", filePathPart, filePath)
+	}
+	downloadSuccess = true
 	return nil
 }
 

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,0 +1,77 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownload_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer server.Close()
+
+	tempDir, err := os.MkdirTemp("", "downloader_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	targetFile := filepath.Join(tempDir, "testfile.txt")
+	manager := New()
+
+	err = manager.Download(context.Background(), server.URL, targetFile, nil)
+	require.NoError(t, err)
+
+	// Check if the final file exists
+	assert.FileExists(t, targetFile)
+
+	// Check if content matches
+	content, err := os.ReadFile(targetFile)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+
+	// Check that the temporary .part file does not exist
+	assert.NoFileExists(t, targetFile+"."+Part)
+}
+
+func TestDownload_Interrupted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(100 * time.Millisecond)
+		_, _ = w.Write([]byte("some data"))
+	}))
+	defer server.Close()
+
+	tempDir, err := os.MkdirTemp("", "downloader_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	targetFile := filepath.Join(tempDir, "testfile.txt")
+	manager := New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the context concurrently
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err = manager.Download(ctx, server.URL, targetFile, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+
+	// Final file should NOT exist
+	assert.NoFileExists(t, targetFile)
+
+	// Temporary .part file should NOT exist because it got cleaned up
+	assert.NoFileExists(t, targetFile+"."+Part)
+}

--- a/internal/downloader/locked.go
+++ b/internal/downloader/locked.go
@@ -55,42 +55,9 @@ func (m *Manager) LockedDownload(ctx context.Context, url, filePath string, forc
 			}
 		}()
 
-		// Create tmpFile where to download.
-		var tmpFileClosed bool
-		tmpPath := filePath + ".downloading"
-		tmpFile, err := os.Create(tmpPath)
-		if err != nil {
-			mainErr = errors.Wrapf(err, "creating temporary file for download in %q", tmpPath)
-			return
-		}
-		defer func() {
-			// If we exit with an error, make sure to close and remove unfinished temporary file.
-			if !tmpFileClosed {
-				err := tmpFile.Close()
-				if err != nil {
-					log.Printf("Failed closing temporary file %q: %v", tmpPath, err)
-				}
-				err = os.Remove(tmpPath)
-				if err != nil {
-					log.Printf("Failed removing temporary file %q: %v", tmpPath, err)
-				}
-			}
-		}()
-
-		mainErr = m.Download(ctx, url, tmpPath, progressCallback)
+		mainErr = m.Download(ctx, url, filePath, progressCallback)
 		if mainErr != nil {
-			mainErr = errors.WithMessagef(mainErr, "while downloading %q to %q", url, tmpPath)
-			return
-		}
-
-		// Download succeeded, move to our target location.
-		tmpFileClosed = true
-		if err := tmpFile.Close(); err != nil {
-			mainErr = errors.Wrapf(err, "failed to close temporary download file %q", tmpPath)
-			return
-		}
-		if err := os.Rename(tmpPath, filePath); err != nil {
-			mainErr = errors.Wrapf(err, "failed to move downloaded file %q to %q", tmpPath, filePath)
+			mainErr = errors.WithMessagef(mainErr, "while downloading %q to %q", url, filePath)
 			return
 		}
 	})

--- a/models/safetensors/iter.go
+++ b/models/safetensors/iter.go
@@ -222,9 +222,7 @@ func iterFromRepoToDevice(backend compute.Backend, done <-chan struct{}, chDevic
 
 	var wg sync.WaitGroup
 	for i := 0; i < MaxParallelBufferTransfers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			var waitTime time.Duration
 			defer func() {
 				totalWaitTime.Add(int64(waitTime))
@@ -277,7 +275,7 @@ func iterFromRepoToDevice(backend compute.Backend, done <-chan struct{}, chDevic
 					waitTime += time.Since(waitStart)
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/tokenizers/bucket/bucket.go
+++ b/tokenizers/bucket/bucket.go
@@ -422,14 +422,12 @@ func (b *Bucketizer) Run(input <-chan SentenceRef, output chan<- Bucket) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < maxParallelization; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for ref := range input {
 				ids := b.tokenizer.Encode(ref.Sentence)
 				results <- tokenized{ref: ref, ids: ids}
 			}
-		}()
+		})
 	}
 
 	go func() {


### PR DESCRIPTION
## Description

This PR contains two main improvements:
1. **Move temporary file handling logic directly to `downloader.Download`:**
   - Previously, downloading to a temporary file (`.downloading`) and renaming on success was managed in `LockedDownload` (`internal/downloader/locked.go`).
   - This logic is now refactored directly into the core `Download` method (`internal/downloader/downloader.go`) using a `.part` suffix. The partial file is automatically cleaned up on failure or interruption/cancellation.
   - Added two new unit tests (`TestDownload_Success` and `TestDownload_Interrupted`) in `internal/downloader/downloader_test.go` to verify this behavior.
   - Simplified `LockedDownload` to delegate directly to `Download`.

2. **Modernize `sync.WaitGroup` usage:**
   - Updated `models/safetensors/iter.go` and `tokenizers/bucket/bucket.go` to use the cleaner and safer `wg.Go(...)` pattern for managing goroutines with `sync.WaitGroup` (available in Go 1.26).

## Commits
* **af2b369** Moved logic that handles downloading to a temporary file first to `downloader.Download` (before it was in `downloader.LockedDownload`)
* **8990f18** Modernized `sync.WaitGroup` usage.
